### PR TITLE
:recycle: 루트 폰트 62.5%로 보정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -44,6 +44,7 @@
 }
 
 html {
+  font-size: 62.5%;
   background-color: #f5f8f9;
   font-family: "Pretendard-Medium";
 }
@@ -53,6 +54,8 @@ body {
   overflow-x: hidden;
   margin: 0;
   padding: 0;
+
+  font-size: 1.6rem;
 }
 
 select {

--- a/src/styles/text.style.js
+++ b/src/styles/text.style.js
@@ -56,8 +56,8 @@ const g1 = css`
 
 const h1 = css`
   font-family: "Pretendard-Bold";
-  font-size: 3rem;
-  letter-spacing: -0.0187rem;
+  font-size: 4.8rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
     font-size: 2rem;
@@ -66,69 +66,69 @@ const h1 = css`
 
 const h2 = css`
   font-family: "Pretendard-SemiBold";
-  font-size: 2.25rem;
-  letter-spacing: -0.0187rem;
+  font-size: 3.6rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 1.5rem;
+    font-size: 2.4rem;
   }
 `;
 
 const h3 = css`
   font-family: "Pretendard-Bold";
-  font-size: 1.625rem;
-  letter-spacing: -0.0187rem;
+  font-size: 2.6rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 1.25rem;
+    font-size: 2rem;
   }
 `;
 
 const h4 = css`
   font-family: "Pretendard-Bold";
-  font-size: 1.25rem;
-  letter-spacing: -0.0187rem;
+  font-size: 2rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 1.125rem;
+    font-size: 1.8rem;
   }
 `;
 
 const s1 = css`
   font-family: "Pretendard-SemiBold";
-  font-size: 1.125rem;
-  letter-spacing: -0.0187rem;
+  font-size: 1.8rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 1rem;
+    font-size: 1.6rem;
   }
 `;
 
 const s2 = css`
   font-family: "Pretendard-SemiBold";
-  font-size: 0.9375rem;
-  letter-spacing: -0.0187rem;
+  font-size: 1.5rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 0.875rem;
+    font-size: 1.4rem;
   }
 `;
 
 const s3 = css`
   font-family: "Pretendard-SemiBold";
-  font-size: 0.875rem;
-  letter-spacing: -0.0187rem;
+  font-size: 1.4rem;
+  letter-spacing: -0.03rem;
 `;
 
 const b1 = css`
   font-family: "Pretendard-Medium";
   font-style: normal;
   font-weight: normal;
-  font-size: 1.0625rem;
-  letter-spacing: -0.0187rem;
+  font-size: 1.7rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 0.9375rem;
+    font-size: 1.5rem;
   }
 `;
 
@@ -136,11 +136,11 @@ const b2 = css`
   font-family: "Pretendard-Medium";
   font-style: normal;
   font-weight: normal;
-  font-size: 0.9375rem;
-  letter-spacing: -0.0187rem;
+  font-size: 1.5rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 0.8125rem;
+    font-size: 1.3rem;
   }
 `;
 
@@ -148,36 +148,36 @@ const b3 = css`
   font-family: "Pretendard-Medium";
   font-style: normal;
   font-weight: normal;
-  font-size: 0.875rem;
-  letter-spacing: -0.0187rem;
+  font-size: 1.4rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 0.8125rem;
+    font-size: 1.3rem;
   }
 `;
 
 const c1 = css`
   font-family: "Pretendard-Medium";
-  font-size: 1rem;
-  letter-spacing: -0.0187rem;
+  font-size: 1.6rem;
+  letter-spacing: -0.03rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 0.8125rem;
+    font-size: 1.3rem;
   }
 `;
 
 const c2 = css`
   font-family: "Pretendard-Regular";
-  font-size: 0.875rem;
+  font-size: 1.4rem;
 
   @media only screen and (max-width: 375px) {
-    font-size: 0.625rem;
+    font-size: 0.1rem;
   }
 `;
 
 const c3 = css`
   font-family: "Pretendard-Medium";
-  font-size: 0.75rem;
+  font-size: 1.2rem;
 `;
 
 export {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [X] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [X] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### 이슈 번호
<!-- 아래 링크에 이슈번호를 적어주세요. 예) .../0-crypto-meter-technokings/issues/7 -->
https://github.com/codeit-bootcamp-frontend/0-crypto-meter-technokings/issues/31

### Key Changes 
- root의 폰트 사이즈를 62.5%로 변경하여 rem단위 사용을 쉽게 만들었습니다.
- body의 폰트 사이즈를 1.6rem으로 설정하여 브라우저 설정 폰트 사이즈에 대응하게 했습니다.
- 기존 16px단위로 설정되어있던 typography의 rem단위들을 보정된 rem값으로 수정했습니다.

### How it Works
- 생략

### To Reviewers
- rem 단위 사용을 전역적으로 할 지, 폰트 사이즈에만 적용할지 논의가 필요해보입니다. 
