### PR TITLE
:recycle: CoinStore 액션 기능 축소

### DIFF
--- a/src/stores/coinStore.js
+++ b/src/stores/coinStore.js
@@ -20,6 +20,7 @@ const mockAxiosMarkets = (currency, coinsPerPage, pageNum, order) => {
  * @param {string} currency 선택한 화폐 단위
  * @returns axios get 요청으로 가져온 180개 코인 리스트 반환
  */
+// eslint-disable-next-line no-unused-vars
 const getCoinsByPage = async (pageNum, coinsPerPage, currency) => {
   const response = await mockAxiosMarkets(
     currency,
@@ -37,89 +38,26 @@ const coinStore = (set, get) => ({
    * @param {string} currency
    * @returns {boolean} 인자로 받은 페이지네이션 넘버에 해당하는 페이지네이션이 coinDB에 있는지 여부를 반환
    */
-  checkCache: (pagiNationNum, currency) => {
-    if (pagiNationNum === 0) return true;
+  checkCache: (pageNum, currency) => {
+    if (pageNum === 0) return true;
     const { coinDB } = get();
-    if (`${currency}_${pagiNationNum}` in coinDB) return true;
+    if (`${currency}_${pageNum}` in coinDB) return true;
     return false;
   },
   /**
    * @param {coinObject[]} coinList 180개 코인 객체가 담긴 배열
-   * @param {number} paginationNum 해당 배열이 몇 번째 페이지에 저장될 지
+   * @param {number} pageNum coinDB에 저장할 페이지(180개 단위) 번호
    * @param {string} currency 화폐 단위
    * @description 파라미터로 받은 정보를 coinDB에 저장
+   * @example addPage(newCoinListFromApiCall, 3, selectedCurrency) -> "krw_3" : [...] 으로 coinDb에 저장
    */
-  saveDataInCoinDB: (coinList, paginationNum, currency) => {
+  addPage: (coinList, pageNum, currency) => {
     set(
       produce((draft) => {
         // eslint-disable-next-line no-param-reassign
-        draft.coinDB[`${currency}_${paginationNum}`] = coinList;
+        draft.coinDB[`${currency}_${pageNum}`] = coinList;
       })
     );
-  },
-  /**
-   * @param {number} pageNum 테이블에 있는 페이지 번호 (30개가 한 페이지)
-   * @param {string} currency 선택한 화폐 단위
-   * @returns {coinObject[]} 파라미터로 받은 페이지 번호를 토대로 coinDB에서 30개를 추출한 배열 반환
-   */
-  getCoinListByPageNum: (pageNum, currency) => {
-    const { coinDB } = get();
-    const paginationNum = Math.ceil(
-      pageNum / import.meta.env.VITE_PAGES_PER_PAGINATION
-    );
-    const startIdx =
-      ((pageNum - 1) % import.meta.env.VITE_PAGES_PER_PAGINATION) *
-      import.meta.env.VITE_COINS_PER_PAGE;
-    const coinList = coinDB[`${currency}_${paginationNum}`].slice(
-      startIdx,
-      startIdx + import.meta.env.VITE_COINS_PER_PAGE
-    );
-    return coinList;
-  },
-  /**
-   * @param {number} pageNum 테이블에 있는 페이지 번호 (30개가 한 페이지)
-   * @param {string} currency 선택한 화폐 단위
-   * @description 요청한 페이지가 coinDB에 있는지 확인 후 없으면 api요청을 통해 coinDB를 갱신 후 요청한 페이지를 반환
-   */
-  getPage: async (pageNum, currency) => {
-    const { checkCache, saveDataInCoinDB, getCoinListByPageNum } = get();
-    // 캐시 체킹 대상 페이지네이션 넘버 2개 추출
-    const pagesPerPagination = import.meta.env.VITE_PAGES_PER_PAGINATION;
-    // 6, 12와 같이 6과 나누어 떨어지는 숫자들은 다르게 처리
-    const currentPaginationNum =
-      pageNum % pagesPerPagination !== 0
-        ? Math.ceil(pageNum / pagesPerPagination)
-        : pageNum / pagesPerPagination;
-    const previousPaginationNum =
-      pageNum % pagesPerPagination !== 0
-        ? Math.floor(pageNum / pagesPerPagination)
-        : pageNum / pagesPerPagination - 1;
-    // 캐시 미스가 나면 api요청을 통해 없는 페이지네이션을 가져와서 coinDB에 저장
-    if (!checkCache(previousPaginationNum, currency)) {
-      try {
-        const newPagination = await getCoinsByPage(
-          previousPaginationNum,
-          import.meta.env.VITE_COINS_PER_PAGE,
-          currency
-        );
-        saveDataInCoinDB(newPagination, previousPaginationNum, currency);
-      } catch (err) {
-        throw new Error(err);
-      }
-    }
-    if (!checkCache(currentPaginationNum, currency)) {
-      try {
-        const newPagination = await getCoinsByPage(
-          currentPaginationNum,
-          import.meta.env.VITE_COINS_PER_PAGE,
-          currency
-        );
-        saveDataInCoinDB(newPagination, currentPaginationNum, currency);
-      } catch (err) {
-        throw new Error(err);
-      }
-    }
-    return getCoinListByPageNum(pageNum, currency);
   },
 });
 


### PR DESCRIPTION
getPage 액션 삭제 및 액션 이름 변경

<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [X] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [X] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### 이슈 번호
<!-- 아래 링크에 이슈번호를 적어주세요. 예) .../0-crypto-meter-technokings/issues/7 -->
https://github.com/codeit-bootcamp-frontend/0-crypto-meter-technokings/issues/50

### Key Changes 
- coinStore의 getPage액션을 삭제했습니다.
- getPage액션의 파생 액션인 getCoinListByPageNum 액션 또한 삭제했습니다.
- saveDataInCoinDB 액션을 addPage로 이름 변경했습니다. 
- 파라미터 이름 중 paginationNum을 pageNum으로 통일시켰습니다.

### How it Works
- 기존 getPage액션이 하던 일들을 컨슈머 컴포넌트들이 나누어 하게 됩니다. 
- addPage는 coinDB에 대한 setState액션을 추상화한 액션입니다. 
- coinStore는 180, 30, 6과 같은 정적인 숫자들과 격리됩니다. 이러한 정적인 숫자들은 전부 컨슈머 컴포넌트에서 액션에 전달해주는 구조로 바뀌게 됩니다. 
- 이로 인해 paginationNum이라는 작명이 주는 모호함을 없애고자 pageNum으로 통일시켰고, coinStore에서 참조하는 모든 pageNum은 coinDB에 저장되는 페이지(180개로 정했던)를 의미합니다.

### To Reviewers
- api를 호출하는 부분은 어떻게 모듈화할 지 고민해봐야겠습니다. hook으로 분리시켜도 되고, 로컬 함수로 그냥 정의해도 크게 반복적인 작업은 없을 것 같긴 합니다.

Closes #50 
