### PR TITLE
InputBoard에 기능 추가 

### DIFF
--- a/src/components/Gnb/SearchHistory/SearchHistory.jsx
+++ b/src/components/Gnb/SearchHistory/SearchHistory.jsx
@@ -2,109 +2,6 @@ import React from "react";
 
 import SearchHistoryPresenter from "./SearchHistoryPresenter";
 
-const MOCK_HISTORY = [
-  {
-    id: 1,
-    coin: {
-      name: "Bitcoin",
-      image:
-        "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579",
-    },
-    before: { date: new Date(2022, 10, 4), money: 10000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-  {
-    id: 2,
-    coin: {
-      name: "Ethereum",
-      image:
-        "https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880",
-    },
-    before: { date: new Date(2022, 10, 4), money: 20000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-  {
-    id: 3,
-    coin: {
-      name: "Tether",
-      image:
-        "https://assets.coingecko.com/coins/images/325/large/Tether.png?1668148663",
-    },
-    before: { date: new Date(2022, 10, 4), money: 30000 },
-    after: { date: new Date(2022, 10, 4), money: 50 },
-  },
-  {
-    id: 4,
-    coin: {
-      name: "BNB",
-      image:
-        "https://assets.coingecko.com/coins/images/825/large/bnb-icon2_2x.png?1644979850",
-    },
-    before: { date: new Date(2022, 10, 4), money: 10000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-  {
-    id: 5,
-    coin: {
-      name: "Bitcoin",
-      image:
-        "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579",
-    },
-    before: { date: new Date(2022, 10, 4), money: 10000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-  {
-    id: 6,
-    coin: {
-      name: "Bitcoin",
-      image:
-        "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579",
-    },
-    before: { date: new Date(2022, 10, 4), money: 10000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-  {
-    id: 7,
-    coin: {
-      name: "Ethereum",
-      image:
-        "https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880",
-    },
-    before: { date: new Date(2022, 10, 4), money: 20000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-  {
-    id: 8,
-    coin: {
-      name: "Tether",
-      image:
-        "https://assets.coingecko.com/coins/images/325/large/Tether.png?1668148663",
-    },
-    before: { date: new Date(2022, 10, 4), money: 30000 },
-    after: { date: new Date(2022, 10, 4), money: 50 },
-  },
-  {
-    id: 9,
-    coin: {
-      name: "BNB",
-      image:
-        "https://assets.coingecko.com/coins/images/825/large/bnb-icon2_2x.png?1644979850",
-    },
-    before: { date: new Date(2022, 10, 4), money: 10000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-  {
-    id: 10,
-    coin: {
-      name: "Bitcoin",
-      image:
-        "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579",
-    },
-    before: { date: new Date(2022, 10, 4), money: 10000 },
-    after: { date: new Date(2022, 10, 4), money: 20000 },
-  },
-];
-
 const SearchHistory = () => {
   // todo: mock 대신 localStorage해서 get 받아올 것
   // coinCurrency에 따라 다른 history를 받아야 함
@@ -115,7 +12,7 @@ const SearchHistory = () => {
 
   return (
     <SearchHistoryPresenter
-      history={MOCK_HISTORY}
+      history={JSON.parse(localStorage.getItem("records")) ?? []}
       onDelete={handleDeleteHistoryClick}
     />
   );

--- a/src/components/Gnb/SearchHistory/SearchHistoryListItem.jsx
+++ b/src/components/Gnb/SearchHistory/SearchHistoryListItem.jsx
@@ -1,39 +1,37 @@
+/* eslint-disable react/jsx-one-expression-per-line */
 import React from "react";
 
 import styled from "styled-components";
 
-import formatMoneyToString from "@/utils/formatMoney";
+import useUserInputStore from "@/stores/userInputStore";
 import { SDiv, SText, colors } from "@styles";
 import { green, red } from "@styles/text.style";
 
 const SearchHistoryListItem = ({ record }) => {
   // Todo: zustand 화폐로 다루기
-  const currency = "usd";
-  const { coin, before, after } = record;
-  const [beforeTime, afterTime] = [before.date, after.date];
+  const { selectedCurrency } = useUserInputStore((state) => ({
+    selectedCurrency: state.selectedCurrency,
+  }));
+  const { coinInfo, before, after } = record;
   const isMoneyIncreased = after.money - before.money >= 0;
-  const [beforeMoney, afterMoney] = [
-    formatMoneyToString(before.money, currency),
-    formatMoneyToString(after.money, currency),
-  ];
 
   return (
     <S.ItemWrapper row act g={12} h={81} mgl={24} mgr={24}>
       <S.ImageWrapper w={28} h={28}>
-        <img src={coin.image} alt={`${coin.name} logo`} />
+        <img src={coinInfo.imageUrl} alt={`${coinInfo.name} logo`} />
       </S.ImageWrapper>
       <S.TextWrapper col g={6}>
         <SText b3 g5>
-          {`만약 ${beforeTime.getFullYear()}년 ${beforeTime.getMonth()}월 ${beforeTime.getDate()}일에 `}
-          <SText s3>{beforeMoney}</SText>
-          <S.KRWText currency={currency}>으</S.KRWText>로
+          {`만약 ${before.dateString}에 `}
+          <SText s3>{before.moneyString}</SText>
+          <S.KRWText currency={selectedCurrency}>으</S.KRWText>로
         </SText>
         <S.Text b2 black>
-          {`${coin.name}을 샀다면, `}
+          {`${coinInfo.name}을 샀다면, `}
           <S.Br />
-          {`${afterTime.getFullYear()}년 ${afterTime.getMonth()}월 ${afterTime.getDate()}일에는 `}
+          {`${after.dateString}에는 `}
           <S.MoneyText s2 isMoneyIncreased={isMoneyIncreased}>
-            {afterMoney}
+            {after.moneyString}
           </S.MoneyText>
           &nbsp;입니다.
         </S.Text>

--- a/src/components/InputBoard/DateInput/DateInput.jsx
+++ b/src/components/InputBoard/DateInput/DateInput.jsx
@@ -86,7 +86,9 @@ const DateInput = ({ selectedDate, onChange }) => {
             ref={datePickerRef}
             selected={selectedDate}
             dateFormat="yyyy년 MM월 dd일"
-            onChange={onChange}
+            onChange={(date) => {
+              onChange(date);
+            }}
             minDate={new Date("2013-04-28")}
             maxDate={new Date()}
           />

--- a/src/components/InputBoard/Dropdown/Dropdown.jsx
+++ b/src/components/InputBoard/Dropdown/Dropdown.jsx
@@ -2,72 +2,16 @@
 /* eslint-disable arrow-body-style */
 import React, { useState } from "react";
 
+import useUserInputStore from "@/stores/userInputStore";
+
 import DropdownPresenter from "./DropdownPresenter";
 
-export const DUMMY_OPTIONS = [
-  {
-    id: "bitcoin",
-    name: "Bitcoin",
-    image:
-      "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579",
-  },
-  {
-    id: "ethereum",
-    name: "Ethereum",
-    image:
-      "https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880",
-  },
-  {
-    id: "tether",
-    name: "Tether",
-    image:
-      "https://assets.coingecko.com/coins/images/325/large/Tether.png?1668148663",
-  },
-  {
-    id: "binancecoin",
-    name: "BNB",
-    image:
-      "https://assets.coingecko.com/coins/images/825/large/bnb-icon2_2x.png?1644979850",
-  },
-  {
-    id: "usd-coin",
-    name: "USD Coin",
-    image:
-      "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
-  },
-  {
-    id: "ripple",
-    name: "XRP",
-    image:
-      "https://assets.coingecko.com/coins/images/44/large/xrp-symbol-white-128.png?1605778731",
-  },
-  {
-    id: "cardano",
-    name: "Cardano",
-    image:
-      "https://assets.coingecko.com/coins/images/975/large/cardano.png?1547034860",
-  },
-  {
-    id: "staked-ether",
-    name: "Lido Staked Ether",
-    image:
-      "https://assets.coingecko.com/coins/images/13442/large/steth_logo.png?1608607546",
-  },
-  {
-    id: "dogecoin",
-    name: "Dogecoin",
-    image:
-      "https://assets.coingecko.com/coins/images/5/large/dogecoin.png?1547792256",
-  },
-];
-
-const Dropdown = ({ options }) => {
+const Dropdown = ({ options, selected }) => {
   // isOpen 상태 빼고 전부 InputBoard에서 Dropdown한테 props로 넘기기
-  const selectedCoinId = "bitcoin";
   const [isOpen, setIsOpen] = useState(false);
-  const selectedCoinInfo = options.find((option) => {
-    return option.id === selectedCoinId;
-  });
+  const { setSelectedCoinInfo } = useUserInputStore((state) => ({
+    setSelectedCoinInfo: state.setSelectedCoinInfo,
+  }));
   return (
     <DropdownPresenter
       isOpen={isOpen}
@@ -75,7 +19,8 @@ const Dropdown = ({ options }) => {
       onClick={() => {
         setIsOpen((prev) => !prev);
       }}
-      selectedValue={selectedCoinInfo}
+      onSelectOption={setSelectedCoinInfo}
+      selectedValue={selected}
       options={options}
     />
   );

--- a/src/components/InputBoard/Dropdown/DropdownList.jsx
+++ b/src/components/InputBoard/Dropdown/DropdownList.jsx
@@ -9,14 +9,20 @@ import { SDiv, colors } from "@styles";
 
 import DropdownListItem from "./DropdownListItem";
 
-const DropdownList = ({ options = [], onClick }) => {
-  // const optionList = options ?? DUMMY_OPTIONS;
+const DropdownList = ({ options = [], onClick, onSelectOption }) => {
   return (
     <S.MainWrapper pd="10px" g8 bg={colors.gray8} br={12} mgt={4}>
       <SDiv col ast g={2}>
         {/* Todo: SearchInput 컴포넌트 추가 */}
         {options.map((item) => (
-          <DropdownListItem key={item.id} option={item} onClick={onClick} />
+          <DropdownListItem
+            key={item.id}
+            option={item}
+            onClick={() => {
+              onClick();
+              onSelectOption(item);
+            }}
+          />
         ))}
       </SDiv>
     </S.MainWrapper>

--- a/src/components/InputBoard/Dropdown/DropdownListItem.jsx
+++ b/src/components/InputBoard/Dropdown/DropdownListItem.jsx
@@ -19,7 +19,7 @@ const DropdownListItem = ({ option, onClick }) => {
       onClick={onClick}
     >
       <S.ImageWrapper w={30} h={30} disableSelect>
-        <img src={option.image} alt={`${option.name} logo`} />
+        <img src={option.imageUrl} alt={`${option.name} logo`} />
       </S.ImageWrapper>
       <SText b1 white disableSelect>
         {option.name}

--- a/src/components/InputBoard/Dropdown/DropdownPresenter.jsx
+++ b/src/components/InputBoard/Dropdown/DropdownPresenter.jsx
@@ -17,15 +17,18 @@ const DropdownPresenter = ({
   isOpen,
   setIsOpen,
   onClick,
+  onSelectOption,
   selectedValue,
   options,
 }) => {
   const { mediaQuery } = useMediaQuery(1200);
   const [isTablet, setIsTablet] = useState(mediaQuery.matches);
   const dropdownRef = useRef(null);
+
   useEffect(() => {
     setIsTablet(mediaQuery.matches);
   }, [mediaQuery]);
+
   useOutsideClick(dropdownRef, () => {
     setIsOpen(false);
   });
@@ -43,7 +46,7 @@ const DropdownPresenter = ({
         <SDiv row sb>
           <SDiv row g={10}>
             <S.ImageWrapper w={30} h={30} disableSelect>
-              <img src={selectedValue.image} alt={`${selectedValue.name}`} />
+              <img src={selectedValue.imageUrl} alt={`${selectedValue.name}`} />
             </S.ImageWrapper>
             <SDiv ct>
               <S.LabelText b1 white disableSelect>
@@ -66,7 +69,12 @@ const DropdownPresenter = ({
         </SDiv>
       </S.DropdownHead>
       {isOpen && (
-        <DropdownList isOpen={isOpen} options={options} onClick={onClick} />
+        <DropdownList
+          isOpen={isOpen}
+          options={options}
+          onClick={onClick}
+          onSelectOption={onSelectOption}
+        />
       )}
     </S.DropdownWrapper>
   );

--- a/src/components/InputBoard/IncreaseMoneyButton/IncreaseMoneyButton.jsx
+++ b/src/components/InputBoard/IncreaseMoneyButton/IncreaseMoneyButton.jsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 import { colors, SButton, SText } from "@styles";
 
-const IncreaseMoneyButton = ({ money = 10000 }) => {
+const IncreaseMoneyButton = ({ money = 10000, onClick }) => {
   return (
     <S.Button
       type="button"
@@ -14,6 +14,7 @@ const IncreaseMoneyButton = ({ money = 10000 }) => {
       h={30}
       pd="6px 12px 6px 12px"
       bd={`1px solid ${colors.gray3}`}
+      onClick={onClick}
     >
       <S.ButtonText b3 white disableSelect>
         {`${money.toLocaleString("ko-KR")}원`}

--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -43,6 +43,9 @@ const InputBoard = () => {
     selectedMoney,
     setSelectedMoney,
     selectedCurrency,
+    calculateMoney,
+    setCalculatedMoney,
+    saveRecord,
   } = useUserInputStore((state) => ({
     selectedCoinInfo: state.selectedCoinInfo,
     selectedDate: state.selectedDate,
@@ -50,18 +53,25 @@ const InputBoard = () => {
     selectedMoney: state.selectedMoney,
     setSelectedMoney: state.setSelectedMoney,
     selectedCurrency: state.selectedCurrency,
+    calculateMoney: state.calculateMoney,
+    setCalculatedMoney: state.setCalculatedMoney,
+    saveRecord: state.saveRecord,
   }));
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    // TOOD: selectMoney, historyDate, 기반으로 계산해서 store에 update
-    // const newMoney = tempUserSelect.selectMoney * 100; // TODO: 임시값, 추후에 api요청하고 차액을 계산
-    // setTempUserSelect({
-    //   ...tempUserSelect,
-    //   selectedMoneyToCalc: newMoney,
-    // });
-  };
   const increaseMoney = (inc) => {
     setSelectedMoney(selectedMoney + Number(inc));
+  };
+  const handleSubmit = () => {
+    calculateMoney().then((res) => {
+      setCalculatedMoney(res);
+      saveRecord(
+        selectedDate,
+        new Date(),
+        selectedMoney,
+        res,
+        selectedCoinInfo.name,
+        selectedCurrency
+      );
+    });
   };
 
   const InputBordPresenterProps = {

--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -1,18 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useState } from "react";
+import React from "react";
 
 import DROPDOWN_LIST from "@/data/dropdownList";
 import * as PAGE from "@/stores/mockData";
 import useUserInputStore from "@/stores/userInputStore";
 
 import InputBoardPresenter from "./InputBoardPresenter";
-
-const MOCK_USER_SELECT_STORE = {
-  selectedCoinId: "bitcoin",
-  historyDate: new Date(),
-  selectMoney: 0,
-  selectMoneyToCalc: 0,
-};
 
 // eslint-disable-next-line no-unused-vars
 const mockAxiosMarkets = (currency, coinsPerPage, pageNum, order) => {
@@ -46,17 +39,18 @@ const InputBoard = () => {
   const {
     selectedCoinInfo,
     selectedDate,
+    setSelectedDate,
     selectedMoney,
     setSelectedMoney,
     selectedCurrency,
   } = useUserInputStore((state) => ({
     selectedCoinInfo: state.selectedCoinInfo,
     selectedDate: state.selectedDate,
+    setSelectedDate: state.setSelectedDate,
     selectedMoney: state.selectedMoney,
     setSelectedMoney: state.setSelectedMoney,
     selectedCurrency: state.selectedCurrency,
   }));
-  const [tempUserSelect, setTempUserSelect] = useState(MOCK_USER_SELECT_STORE);
   const handleSubmit = (e) => {
     e.preventDefault();
     // TOOD: selectMoney, historyDate, 기반으로 계산해서 store에 update
@@ -75,11 +69,11 @@ const InputBoard = () => {
     selectedDate,
     selectedMoney,
     selectedCurrency,
-    selectMoneyToCalc: tempUserSelect.selectMoneyToCalc,
     dropdownCoinOptionList: DROPDOWN_LIST,
     onSubmit: handleSubmit,
     onChangeMoney: setSelectedMoney,
     onClickIncreaseMoney: increaseMoney,
+    onChangeDate: setSelectedDate,
   };
   return <InputBoardPresenter {...InputBordPresenterProps} />;
 };

--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
+import * as PAGE from "@/stores/mockData";
 import useUserInputStore from "@/stores/userInputStore";
 
-import { DUMMY_OPTIONS } from "./Dropdown/Dropdown";
 import InputBoardPresenter from "./InputBoardPresenter";
 
 const MOCK_USER_SELECT_STORE = {
@@ -13,24 +13,50 @@ const MOCK_USER_SELECT_STORE = {
   selectMoneyToCalc: 0,
 };
 
-const MOCK_COINLIST_STORE = {
-  coinCurrency: "krw",
-  dropdownCoinOptionList: DUMMY_OPTIONS,
+// eslint-disable-next-line no-unused-vars
+const mockAxiosMarkets = (currency, coinsPerPage, pageNum, order) => {
+  // eslint-disable-next-line max-len
+  // 'BASE_URL/coins/markets?vs_currency=krw&order=market_cap_desc&per_page=180&page=2&sparkline=false&locale=en'
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      // 파라미터 받은대로 요청 후 가져옴
+      resolve(PAGE[`${currency}_${pageNum}`]);
+    }, 500);
+  });
+};
+/**
+ * @param {number} pageNum 페이지네이션 넘버 (180개 단위 페이지)
+ * @param {number} coinsPerPage 페이지 당 가져올 코인 갯수(180)
+ * @param {string} currency 선택한 화폐 단위
+ * @returns axios get 요청으로 가져온 180개 코인 리스트 반환
+ */
+// eslint-disable-next-line no-unused-vars
+const getCoinsByPage = async (pageNum, coinsPerPage, currency) => {
+  const response = await mockAxiosMarkets(
+    currency,
+    coinsPerPage,
+    pageNum,
+    "market_cap_desc"
+  );
+  return response;
 };
 
 const InputBoard = () => {
-  const { selectedCoinInfo, selectedDate, selectedMoney, selectedCurrency } =
-    useUserInputStore((state) => ({
-      selectedCoinInfo: state.selectedCoinInfo,
-      selectedDate: state.selectedDate,
-      selectedMoney: state.selectedMoney,
-      selectedCurrency: state.selectedCurrency,
-    }));
-
+  const {
+    selectedCoinInfo,
+    setSelectedCoinInfo,
+    selectedDate,
+    selectedMoney,
+    selectedCurrency,
+  } = useUserInputStore((state) => ({
+    selectedCoinInfo: state.selectedCoinInfo,
+    setSelectedCoinInfo: state.setSelectedCoinInfo,
+    selectedDate: state.selectedDate,
+    selectedMoney: state.selectedMoney,
+    selectedCurrency: state.selectedCurrency,
+  }));
   const [tempUserSelect, setTempUserSelect] = useState(MOCK_USER_SELECT_STORE);
-  // eslint-disable-next-line no-unused-vars
-  const [tempCoinList, setTempCoinList] = useState(MOCK_COINLIST_STORE);
-
+  const [dropdownList, setDropdownList] = useState([]);
   const handleSubmit = (e) => {
     e.preventDefault();
     // TOOD: selectMoney, historyDate, 기반으로 계산해서 store에 update
@@ -49,9 +75,26 @@ const InputBoard = () => {
     setTempUserSelect({ ...tempUserSelect, selectMoney: newMoney });
   };
 
-  const handleChangeSelectedCoin = (newCoinId) => {
-    setTempUserSelect({ ...tempUserSelect, selectedCoinId: newCoinId });
+  const handleChangeSelectedCoin = (newCoinInfo) => {
+    setSelectedCoinInfo(newCoinInfo);
   };
+
+  useEffect(() => {
+    const getDropdownList = async () => {
+      const response = await getCoinsByPage(
+        1,
+        import.meta.VITE_COINS_PER_PAGE,
+        "krw"
+      );
+      return response.map((coinInfo) => ({
+        id: coinInfo.id,
+        name: coinInfo.name,
+        imageUrl: coinInfo.image,
+      }));
+    };
+
+    getDropdownList().then((coins) => setDropdownList(coins));
+  }, []);
 
   const InputBordPresenterProps = {
     selectedCoinInfo,
@@ -59,13 +102,12 @@ const InputBoard = () => {
     selectedMoney,
     selectedCurrency,
     selectMoneyToCalc: tempUserSelect.selectMoneyToCalc,
-    dropdownCoinOptionList: tempCoinList.dropdownCoinOptionList,
+    dropdownCoinOptionList: dropdownList,
     onSubmit: handleSubmit,
     onChangeMoney: handleChangeSelectMoney,
     onChangeDate: handleChangeHistoryDate,
     onChangeCoin: handleChangeSelectedCoin,
   };
-
   return <InputBoardPresenter {...InputBordPresenterProps} />;
 };
 

--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -57,9 +57,11 @@ const InputBoard = () => {
     setCalculatedMoney: state.setCalculatedMoney,
     saveRecord: state.saveRecord,
   }));
+
   const increaseMoney = (inc) => {
     setSelectedMoney(selectedMoney + Number(inc));
   };
+
   const handleSubmit = () => {
     calculateMoney().then((res) => {
       setCalculatedMoney(res);
@@ -68,7 +70,7 @@ const InputBoard = () => {
         new Date(),
         selectedMoney,
         res,
-        selectedCoinInfo.name,
+        selectedCoinInfo,
         selectedCurrency
       );
     });

--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 
+import DROPDOWN_LIST from "@/data/dropdownList";
 import * as PAGE from "@/stores/mockData";
 import useUserInputStore from "@/stores/userInputStore";
 
@@ -56,35 +57,18 @@ const InputBoard = () => {
     selectedCurrency: state.selectedCurrency,
   }));
   const [tempUserSelect, setTempUserSelect] = useState(MOCK_USER_SELECT_STORE);
-  const [dropdownList, setDropdownList] = useState([]);
   const handleSubmit = (e) => {
     e.preventDefault();
     // TOOD: selectMoney, historyDate, 기반으로 계산해서 store에 update
-    const newMoney = tempUserSelect.selectMoney * 100; // TODO: 임시값, 추후에 api요청하고 차액을 계산
-    setTempUserSelect({
-      ...tempUserSelect,
-      selectedMoneyToCalc: newMoney,
-    });
+    // const newMoney = tempUserSelect.selectMoney * 100; // TODO: 임시값, 추후에 api요청하고 차액을 계산
+    // setTempUserSelect({
+    //   ...tempUserSelect,
+    //   selectedMoneyToCalc: newMoney,
+    // });
   };
   const increaseMoney = (inc) => {
-    setSelectedMoney(selectedMoney + inc);
+    setSelectedMoney(selectedMoney + Number(inc));
   };
-  useEffect(() => {
-    const getDropdownList = async () => {
-      const response = await getCoinsByPage(
-        1,
-        import.meta.VITE_COINS_PER_PAGE,
-        "krw"
-      );
-      return response.map((coinInfo) => ({
-        id: coinInfo.id,
-        name: coinInfo.name,
-        imageUrl: coinInfo.image,
-      }));
-    };
-
-    getDropdownList().then((coins) => setDropdownList(coins));
-  }, []);
 
   const InputBordPresenterProps = {
     selectedCoinInfo,
@@ -92,7 +76,7 @@ const InputBoard = () => {
     selectedMoney,
     selectedCurrency,
     selectMoneyToCalc: tempUserSelect.selectMoneyToCalc,
-    dropdownCoinOptionList: dropdownList,
+    dropdownCoinOptionList: DROPDOWN_LIST,
     onSubmit: handleSubmit,
     onChangeMoney: setSelectedMoney,
     onClickIncreaseMoney: increaseMoney,

--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -44,15 +44,15 @@ const getCoinsByPage = async (pageNum, coinsPerPage, currency) => {
 const InputBoard = () => {
   const {
     selectedCoinInfo,
-    setSelectedCoinInfo,
     selectedDate,
     selectedMoney,
+    setSelectedMoney,
     selectedCurrency,
   } = useUserInputStore((state) => ({
     selectedCoinInfo: state.selectedCoinInfo,
-    setSelectedCoinInfo: state.setSelectedCoinInfo,
     selectedDate: state.selectedDate,
     selectedMoney: state.selectedMoney,
+    setSelectedMoney: state.setSelectedMoney,
     selectedCurrency: state.selectedCurrency,
   }));
   const [tempUserSelect, setTempUserSelect] = useState(MOCK_USER_SELECT_STORE);
@@ -66,19 +66,9 @@ const InputBoard = () => {
       selectedMoneyToCalc: newMoney,
     });
   };
-  // TODO: 아래 임시 세터 함수들 전부 zustand store의 set으로 구현
-  const handleChangeHistoryDate = (newDate) => {
-    setTempUserSelect({ ...tempUserSelect, historyDate: newDate });
+  const increaseMoney = (inc) => {
+    setSelectedMoney(selectedMoney + inc);
   };
-
-  const handleChangeSelectMoney = (newMoney) => {
-    setTempUserSelect({ ...tempUserSelect, selectMoney: newMoney });
-  };
-
-  const handleChangeSelectedCoin = (newCoinInfo) => {
-    setSelectedCoinInfo(newCoinInfo);
-  };
-
   useEffect(() => {
     const getDropdownList = async () => {
       const response = await getCoinsByPage(
@@ -104,9 +94,8 @@ const InputBoard = () => {
     selectMoneyToCalc: tempUserSelect.selectMoneyToCalc,
     dropdownCoinOptionList: dropdownList,
     onSubmit: handleSubmit,
-    onChangeMoney: handleChangeSelectMoney,
-    onChangeDate: handleChangeHistoryDate,
-    onChangeCoin: handleChangeSelectedCoin,
+    onChangeMoney: setSelectedMoney,
+    onClickIncreaseMoney: increaseMoney,
   };
   return <InputBoardPresenter {...InputBordPresenterProps} />;
 };

--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { useState } from "react";
 
+import useUserInputStore from "@/stores/userInputStore";
+
 import { DUMMY_OPTIONS } from "./Dropdown/Dropdown";
 import InputBoardPresenter from "./InputBoardPresenter";
 
@@ -17,6 +19,14 @@ const MOCK_COINLIST_STORE = {
 };
 
 const InputBoard = () => {
+  const { selectedCoinInfo, selectedDate, selectedMoney, selectedCurrency } =
+    useUserInputStore((state) => ({
+      selectedCoinInfo: state.selectedCoinInfo,
+      selectedDate: state.selectedDate,
+      selectedMoney: state.selectedMoney,
+      selectedCurrency: state.selectedCurrency,
+    }));
+
   const [tempUserSelect, setTempUserSelect] = useState(MOCK_USER_SELECT_STORE);
   // eslint-disable-next-line no-unused-vars
   const [tempCoinList, setTempCoinList] = useState(MOCK_COINLIST_STORE);
@@ -44,10 +54,10 @@ const InputBoard = () => {
   };
 
   const InputBordPresenterProps = {
-    selectedCoinId: tempUserSelect.selectedCoinId,
-    historyDate: tempUserSelect.historyDate,
-    selectMoney: tempUserSelect.selectMoney,
-    selectedCurrency: tempCoinList.coinCurrency,
+    selectedCoinInfo,
+    selectedDate,
+    selectedMoney,
+    selectedCurrency,
     selectMoneyToCalc: tempUserSelect.selectMoneyToCalc,
     dropdownCoinOptionList: tempCoinList.dropdownCoinOptionList,
     onSubmit: handleSubmit,

--- a/src/components/InputBoard/InputBoardPresenter.jsx
+++ b/src/components/InputBoard/InputBoardPresenter.jsx
@@ -23,15 +23,12 @@ const InputBoardPresenter = ({
   selectedCurrency,
   dropdownCoinOptionList,
   onSubmit,
-  onChangeDate,
+  onChangeMoney,
+  onClickIncreaseMoney,
 }) => {
   const [isOpen, setIsOpen] = useState(false); // form 모달이 열렸는지
   const { mediaQuery } = useMediaQuery(1200); // 미디어쿼리 변화 감지
   const [isTablet, setIsTablet] = useState(mediaQuery.matches); // 태블릿 사이즈 이하인지
-
-  const handleClickIncreaseMoney = () => {
-    // TODO: zustand store의 selectedMoney를 increase하기
-  };
 
   useEffect(() => {
     if (!isTablet) {
@@ -85,17 +82,21 @@ const InputBoardPresenter = ({
           <S.InputArea col g={25} full className="GI">
             <DateInput
               selectedDate={selectedDate} // TODO: historyDate를 받아온다.
-              onChange={onChangeDate}
+              onChange={() => {}}
             />
             <SDiv col act g={12}>
-              <MoneyInput selectedMoney="15000" isOpen={false} />
+              <MoneyInput
+                selectedMoney={selectedMoney}
+                onChange={onChangeMoney}
+                isOpen={false}
+              />
               <S.IncreaseButtonListWrapper row sb full>
                 {INCREASE_MONEY_UNITS.map((unit) => (
                   <IncreaseMoneyButton
                     key={unit}
                     money={unit}
                     onClick={() => {
-                      handleClickIncreaseMoney(unit);
+                      onClickIncreaseMoney(unit);
                     }}
                   />
                 ))}

--- a/src/components/InputBoard/InputBoardPresenter.jsx
+++ b/src/components/InputBoard/InputBoardPresenter.jsx
@@ -101,7 +101,10 @@ const InputBoardPresenter = ({
                 ))}
               </S.IncreaseButtonListWrapper>
             </SDiv>
-            <Dropdown options={dropdownCoinOptionList} />
+            <Dropdown
+              options={dropdownCoinOptionList}
+              selected={selectedCoinInfo}
+            />
           </S.InputArea>
           <S.SubmitArea ct>
             <S.SubmitButton

--- a/src/components/InputBoard/InputBoardPresenter.jsx
+++ b/src/components/InputBoard/InputBoardPresenter.jsx
@@ -77,7 +77,7 @@ const InputBoardPresenter = ({
           onSubmit={(e) => {
             e.preventDefault();
             setIsOpen(false);
-            onSubmit(e);
+            onSubmit();
           }}
         >
           <S.InputArea col g={25} full>
@@ -117,7 +117,7 @@ const InputBoardPresenter = ({
               type="submit"
               onSubmit={(e) => {
                 e.preventDefault();
-                onSubmit(e);
+                onSubmit();
                 setIsOpen(false);
               }}
             >

--- a/src/components/InputBoard/InputBoardPresenter.jsx
+++ b/src/components/InputBoard/InputBoardPresenter.jsx
@@ -25,6 +25,7 @@ const InputBoardPresenter = ({
   onSubmit,
   onChangeMoney,
   onClickIncreaseMoney,
+  onChangeDate,
 }) => {
   const [isOpen, setIsOpen] = useState(false); // form 모달이 열렸는지
   const { mediaQuery } = useMediaQuery(1200); // 미디어쿼리 변화 감지
@@ -79,10 +80,10 @@ const InputBoardPresenter = ({
             onSubmit(e);
           }}
         >
-          <S.InputArea col g={25} full className="GI">
+          <S.InputArea col g={25} full>
             <DateInput
               selectedDate={selectedDate} // TODO: historyDate를 받아온다.
-              onChange={() => {}}
+              onChange={onChangeDate}
             />
             <SDiv col act g={12}>
               <MoneyInput

--- a/src/components/InputBoard/InputBoardPresenter.jsx
+++ b/src/components/InputBoard/InputBoardPresenter.jsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 
 import useMediaQuery from "@/hooks/useMediaQuery";
 import formatDateToString from "@/utils/formatDate";
+import formatMoneyToString from "@/utils/formatMoney";
 import FilterIcon from "@components/SVGComponents/FilterIcon";
 import { SDiv, SButton, SText, colors, SHeading2 } from "@styles";
 
@@ -16,9 +17,10 @@ import MoneyInput from "./MoneyInput/MoneyInput";
 const INCREASE_MONEY_UNITS = [5000, 10000, 50000, 100000];
 
 const InputBoardPresenter = ({
-  selectedCoinId,
-  historyDate,
-  selectMoney,
+  selectedCoinInfo,
+  selectedDate,
+  selectedMoney,
+  selectedCurrency,
   dropdownCoinOptionList,
   onSubmit,
   onChangeDate,
@@ -56,16 +58,16 @@ const InputBoardPresenter = ({
           <SText mgb={7}> 내가 만약&nbsp;</SText>
           <S.Br first />
           <SText white mgb={7}>
-            {formatDateToString(historyDate) || "0000년 00월 00일"}
+            {formatDateToString(selectedDate)}
           </SText>
           에
           <S.Br second />
           <SText white mgb={7}>
-            {selectMoney || 0}
+            {formatMoneyToString(selectedMoney, selectedCurrency)}
           </SText>
-          원으로&nbsp;
+          으로&nbsp;
           <S.Br third />
-          <SText white>{selectedCoinId || "Bitcoin"}</SText>을 샀다면,
+          <SText white>{selectedCoinInfo.name}</SText>을 샀다면,
         </SHeading2>
         <S.Overlay
           show={isTablet && isOpen}
@@ -82,7 +84,7 @@ const InputBoardPresenter = ({
         >
           <S.InputArea col g={25} full className="GI">
             <DateInput
-              selectedDate={historyDate} // TODO: historyDate를 받아온다.
+              selectedDate={selectedDate} // TODO: historyDate를 받아온다.
               onChange={onChangeDate}
             />
             <SDiv col act g={12}>

--- a/src/components/InputBoard/MoneyInput/MoneyInput.jsx
+++ b/src/components/InputBoard/MoneyInput/MoneyInput.jsx
@@ -11,15 +11,13 @@ const MoneyInput = ({ isOpen, onChange, selectedMoney }) => {
     symbol: "₩",
     value: "krw",
   };
-  const [inputValue, setInputValue] = useState(selectedMoney);
+
   const [showInput, setShowInput] = useState(true);
   const inputRef = useRef(null);
 
   useEffect(() => {
-    if (showInput) {
-      if (inputRef.current) {
-        inputRef.current.focus();
-      }
+    if (showInput && inputRef.current) {
+      inputRef.current.focus();
     }
   }, [showInput]);
 
@@ -36,8 +34,9 @@ const MoneyInput = ({ isOpen, onChange, selectedMoney }) => {
           min="1"
           ct
           placeholder={new Intl.NumberFormat().format(selectedMoney)}
+          value={selectedMoney}
           onChange={(e) => {
-            setInputValue(e.target.value);
+            onChange(Number(e.target.value));
           }}
           onFocus={() => {
             setShowInput(true);
@@ -54,7 +53,7 @@ const MoneyInput = ({ isOpen, onChange, selectedMoney }) => {
           }}
           show={!showInput}
         >
-          {new Intl.NumberFormat().format(inputValue)}
+          {new Intl.NumberFormat().format(selectedMoney)}
         </S.InputValueWrapper>
         <SDiv ct>
           <S.LabelText b1 white disableSelect>

--- a/src/data/dropdownList.js
+++ b/src/data/dropdownList.js
@@ -345,7 +345,7 @@ const DROPDOWN_LIST = [
     id: "flow",
     name: "Flow",
     imageUrl:
-      "https://assets.coingecko.com/coins/images/13446/la…94c0c7a8cda55cb1c936_Flow_Wordmark.png?1631696776",
+      "https://assets.coingecko.com/coins/images/13446/large/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.png?1631696776",
   },
   {
     id: "havven",
@@ -771,7 +771,7 @@ const DROPDOWN_LIST = [
     id: "marumarunft",
     name: "marumaruNFT",
     imageUrl:
-      "https://assets.coingecko.com/coins/images/27672/la…e23f86-426d-4a0f-9d66-10da3d58baf5.png?1665158519",
+      "https://assets.coingecko.com/coins/images/27672/large/90e23f86-426d-4a0f-9d66-10da3d58baf5.png?1665158519",
   },
   {
     id: "liquity-usd",

--- a/src/data/dropdownList.js
+++ b/src/data/dropdownList.js
@@ -1,0 +1,1077 @@
+const DROPDOWN_LIST = [
+  {
+    id: "bitcoin",
+    name: "Bitcoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579",
+  },
+  {
+    id: "ethereum",
+    name: "Ethereum",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880",
+  },
+  {
+    id: "tether",
+    name: "Tether",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/325/large/Tether.png?1668148663",
+  },
+  {
+    id: "binancecoin",
+    name: "BNB",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/825/large/bnb-icon2_2x.png?1644979850",
+  },
+  {
+    id: "usd-coin",
+    name: "USD Coin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
+  },
+  {
+    id: "ripple",
+    name: "XRP",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/44/large/xrp-symbol-white-128.png?1605778731",
+  },
+  {
+    id: "cardano",
+    name: "Cardano",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/975/large/cardano.png?1547034860",
+  },
+  {
+    id: "staked-ether",
+    name: "Lido Staked Ether",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13442/large/steth_logo.png?1608607546",
+  },
+  {
+    id: "dogecoin",
+    name: "Dogecoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/5/large/dogecoin.png?1547792256",
+  },
+  {
+    id: "matic-network",
+    name: "Polygon",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4713/large/matic-token-icon.png?1624446912",
+  },
+  {
+    id: "solana",
+    name: "Solana",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4128/large/solana.png?1640133422",
+  },
+  {
+    id: "litecoin",
+    name: "Litecoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2/large/litecoin.png?1547033580",
+  },
+  {
+    id: "polkadot",
+    name: "Polkadot",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12171/large/polkadot.png?1639712644",
+  },
+  {
+    id: "tron",
+    name: "TRON",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1094/large/tron-logo.png?1547035066",
+  },
+  {
+    id: "shiba-inu",
+    name: "Shiba Inu",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11939/large/shiba.png?1622619446",
+  },
+  {
+    id: "avalanche-2",
+    name: "Avalanche",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12559/large/Avalanche_Circle_RedWhite_Trans.png?1670992574",
+  },
+  {
+    id: "dai",
+    name: "Dai",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9956/large/4943.png?1636636734",
+  },
+  {
+    id: "wrapped-bitcoin",
+    name: "Wrapped Bitcoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1548822744",
+  },
+  {
+    id: "uniswap",
+    name: "Uniswap",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12504/large/uniswap-uni.png?1600306604",
+  },
+  {
+    id: "leo-token",
+    name: "LEO Token",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/8418/large/leo-token.png?1558326215",
+  },
+  {
+    id: "chainlink",
+    name: "Chainlink",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png?1547034700",
+  },
+  {
+    id: "cosmos",
+    name: "Cosmos Hub",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1481/large/cosmos_hub.png?1555657960",
+  },
+  {
+    id: "the-open-network",
+    name: "Toncoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/17980/large/ton_symbol.png?1670498136",
+  },
+  {
+    id: "okb",
+    name: "OKB",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4463/large/WeChat_Image_20220118095654.png?1642471050",
+  },
+  {
+    id: "monero",
+    name: "Monero",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/69/large/monero_logo.png?1547033729",
+  },
+  {
+    id: "ethereum-classic",
+    name: "Ethereum Classic",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/453/large/ethereum-classic-logo.png?1547034169",
+  },
+  {
+    id: "stellar",
+    name: "Stellar",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/100/large/Stellar_symbol_black_RGB.png?1552356157",
+  },
+  {
+    id: "internet-computer",
+    name: "Internet Computer",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/14495/large/Internet_Computer_logo.png?1620703073",
+  },
+  {
+    id: "bitcoin-cash",
+    name: "Bitcoin Cash",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/780/large/bitcoin-cash-circle.png?1594689492",
+  },
+  {
+    id: "true-usd",
+    name: "TrueUSD",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3449/large/tusd.png?1618395665",
+  },
+  {
+    id: "filecoin",
+    name: "Filecoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12817/large/filecoin.png?1602753933",
+  },
+  {
+    id: "lido-dao",
+    name: "Lido DAO",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13573/large/Lido_DAO.png?1609873644",
+  },
+  {
+    id: "hedera-hashgraph",
+    name: "Hedera",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3688/large/hbar.png?1637045634",
+  },
+  {
+    id: "aptos",
+    name: "Aptos",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/26455/large/aptos_round.png?1666839629",
+  },
+  {
+    id: "crypto-com-chain",
+    name: "Cronos",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/7310/large/cro_token_logo.png?1669699773",
+  },
+  {
+    id: "quant-network",
+    name: "Quant",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3370/large/5ZOu7brX_400x400.jpg?1612437252",
+  },
+  {
+    id: "near",
+    name: "NEAR Protocol",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/10365/large/near.jpg?1683515160",
+  },
+  {
+    id: "arbitrum",
+    name: "Arbitrum",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/16547/large/photo_2023-03-29_21.47.00.jpeg?1680097630",
+  },
+  {
+    id: "vechain",
+    name: "VeChain",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1167/large/VET_Token_Icon.png?1680067517",
+  },
+  {
+    id: "apecoin",
+    name: "ApeCoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/24383/large/apecoin.jpg?1647476455",
+  },
+  {
+    id: "algorand",
+    name: "Algorand",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4380/large/download.png?1547039725",
+  },
+  {
+    id: "the-graph",
+    name: "The Graph",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1608145566",
+  },
+  {
+    id: "fantom",
+    name: "Fantom",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4001/large/Fantom_round.png?1669652346",
+  },
+  {
+    id: "paxos-standard",
+    name: "Pax Dollar",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/6013/large/Pax_Dollar.png?1629877204",
+  },
+  {
+    id: "frax",
+    name: "Frax",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13422/large/FRAX_icon.png?1679886922",
+  },
+  {
+    id: "edgecoin-2",
+    name: "Edgecoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/14409/large/edgecoin_bank_logo-4_%281%29.png?1673251201",
+  },
+  {
+    id: "the-sandbox",
+    name: "The Sandbox",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12129/large/sandbox_logo.jpg?1597397942",
+  },
+  {
+    id: "eos",
+    name: "EOS",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/738/large/eos-eos-logo.png?1547034481",
+  },
+  {
+    id: "rocket-pool",
+    name: "Rocket Pool",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1637662441",
+  },
+  {
+    id: "elrond-erd-2",
+    name: "MultiversX",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12335/large/egld-token-logo.png?1673490885",
+  },
+  {
+    id: "aave",
+    name: "Aave",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12645/large/AAVE.png?1601374110",
+  },
+  {
+    id: "blockstack",
+    name: "Stacks",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2069/large/Stacks_logo_full.png?1604112510",
+  },
+  {
+    id: "decentraland",
+    name: "Decentraland",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/878/large/decentraland-mana.png?1550108745",
+  },
+  {
+    id: "theta-token",
+    name: "Theta Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2538/large/theta-token-logo.png?1548387191",
+  },
+  {
+    id: "render-token",
+    name: "Render",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11636/large/rndr.png?1638840934",
+  },
+  {
+    id: "tezos",
+    name: "Tezos",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/976/large/Tezos-logo.png?1547034862",
+  },
+  {
+    id: "axie-infinity",
+    name: "Axie Infinity",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13029/large/axie_infinity_logo.png?1604471082",
+  },
+  {
+    id: "flow",
+    name: "Flow",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13446/la…94c0c7a8cda55cb1c936_Flow_Wordmark.png?1631696776",
+  },
+  {
+    id: "havven",
+    name: "Synthetix Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3406/large/SNX.png?1598631139",
+  },
+  {
+    id: "bitdao",
+    name: "BitDAO",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/17627/large/rI_YptK8.png?1653983088",
+  },
+  {
+    id: "immutable-x",
+    name: "ImmutableX",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/17233/large/immutableX-symbol-BLK-RGB.png?1665110648",
+  },
+  {
+    id: "gala",
+    name: "GALA",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12493/large/GALA-COINGECKO.png?1600233435",
+  },
+  {
+    id: "usdd",
+    name: "USDD",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/25380/large/UUSD.jpg?1651823371",
+  },
+  {
+    id: "radix",
+    name: "Radix",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4374/large/Radix.png?1629701658",
+  },
+  {
+    id: "pepe",
+    name: "Pepe",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1682922725",
+  },
+  {
+    id: "kucoin-shares",
+    name: "KuCoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1047/large/sa9z79.png?1610678720",
+  },
+  {
+    id: "rocket-pool-eth",
+    name: "Rocket Pool ETH",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/20764/large/reth.png?1637652366",
+  },
+  {
+    id: "gatechain-token",
+    name: "Gate",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/8183/large/gt.png?1556085624",
+  },
+  {
+    id: "curve-dao-token",
+    name: "Curve DAO",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12124/large/Curve.png?1597369484",
+  },
+  {
+    id: "bitcoin-cash-sv",
+    name: "Bitcoin SV",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/6799/large/BSV.png?1558947902",
+  },
+  {
+    id: "whitebit",
+    name: "WhiteBIT Token",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/27045/large/wbt_token.png?1667923752",
+  },
+  {
+    id: "bitget-token",
+    name: "Bitget Token",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11610/large/photo_2022-01-24_14-08-03.jpg?1643019457",
+  },
+  {
+    id: "neo",
+    name: "NEO",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/480/large/NEO_512_512.png?1594357361",
+  },
+  {
+    id: "conflux-token",
+    name: "Conflux",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13079/large/3vuYMbjN.png?1631512305",
+  },
+  {
+    id: "sui",
+    name: "Sui",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/26375/large/sui_asset.jpeg?1683114182",
+  },
+  {
+    id: "gemini-dollar",
+    name: "Gemini Dollar",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/5992/large/gemini-dollar-gusd.png?1536745278",
+  },
+  {
+    id: "chiliz",
+    name: "Chiliz",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/8834/large/CHZ_Token_updated.png?1675848257",
+  },
+  {
+    id: "bittorrent",
+    name: "BitTorrent",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/22457/large/btt_logo.png?1643857231",
+  },
+  {
+    id: "maker",
+    name: "Maker",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1364/large/Mark_Maker.png?1585191826",
+  },
+  {
+    id: "injective-protocol",
+    name: "Injective",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12882/large/Secondary_Symbol.png?1628233237",
+  },
+  {
+    id: "klay-token",
+    name: "Klaytn",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9672/large/klaytn.png?1660288824",
+  },
+  {
+    id: "optimism",
+    name: "Optimism",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/25244/large/Optimism.png?1660904599",
+  },
+  {
+    id: "casper-network",
+    name: "Casper Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/15279/large/casper.PNG?1620341020",
+  },
+  {
+    id: "kava",
+    name: "Kava",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9761/large/kava.png?1663638871",
+  },
+  {
+    id: "gmx",
+    name: "GMX",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1631532468",
+  },
+  {
+    id: "terra-luna",
+    name: "Terra Luna Classic",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/8284/large/01_LunaClassic_color.png?1653547790",
+  },
+  {
+    id: "mina-protocol",
+    name: "Mina Protocol",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/15628/large/JM4_vQ34_400x400.png?1621394004",
+  },
+  {
+    id: "pax-gold",
+    name: "PAX Gold",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9519/large/paxg.PNG?1568542565",
+  },
+  {
+    id: "frax-share",
+    name: "Frax Share",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13423/large/Frax_Shares_icon.png?1679886947",
+  },
+  {
+    id: "ecash",
+    name: "eCash",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/16646/large/Logo_final-22.png?1628239446",
+  },
+  {
+    id: "tokenize-xchange",
+    name: "Tokenize Xchange",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4984/large/TKX_-_Logo_-_RGB-15.png?1672912391",
+  },
+  {
+    id: "iota",
+    name: "IOTA",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/692/large/IOTA_Swirl.png?1604238557",
+  },
+  {
+    id: "dash",
+    name: "Dash",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/19/large/dash-logo.png?1548385930",
+  },
+  {
+    id: "tether-gold",
+    name: "Tether Gold",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/10481/large/Tether_Gold.png?1668148656",
+  },
+  {
+    id: "huobi-token",
+    name: "Huobi",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2822/large/huobi-token-logo.png?1547036992",
+  },
+  {
+    id: "compound-ether",
+    name: "cETH",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/10643/large/ceth2.JPG?1581389598",
+  },
+  {
+    id: "flare-networks",
+    name: "Flare",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/28624/large/FLR-icon200x200.png?1673325704",
+  },
+  {
+    id: "trust-wallet-token",
+    name: "Trust Wallet",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11085/large/Trust.png?1588062702",
+  },
+  {
+    id: "xdce-crowd-sale",
+    name: "XDC Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2912/large/xdc-icon.png?1633700890",
+  },
+  {
+    id: "zilliqa",
+    name: "Zilliqa",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2687/large/Zilliqa-logo.png?1547036894",
+  },
+  {
+    id: "compound-usd-coin",
+    name: "cUSDC",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9442/large/Compound_USDC.png?1567581577",
+  },
+  {
+    id: "woo-network",
+    name: "WOO Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12921/large/w2UiemF__400x400.jpg?1603670367",
+  },
+  {
+    id: "frax-ether",
+    name: "Frax Ether",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/28284/large/frxETH_icon.png?1679886981",
+  },
+  {
+    id: "nexo",
+    name: "NEXO",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3695/large/nexo.png?1548086057",
+  },
+  {
+    id: "pancakeswap-token",
+    name: "PancakeSwap",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1629359065",
+  },
+  {
+    id: "loopring",
+    name: "Loopring",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/913/large/LRC.png?1572852344",
+  },
+  {
+    id: "mask-network",
+    name: "Mask Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/14051/large/Mask_Network.jpg?1614050316",
+  },
+  {
+    id: "convex-finance",
+    name: "Convex Finance",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/15585/large/convex.png?1621256328",
+  },
+  {
+    id: "osmosis",
+    name: "Osmosis",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/16724/large/osmo.png?1632763885",
+  },
+  {
+    id: "enjincoin",
+    name: "Enjin Coin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1102/large/enjin-coin-logo.png?1547035078",
+  },
+  {
+    id: "thorchain",
+    name: "THORChain",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/6595/large/Rune200x200.png?1671179394",
+  },
+  {
+    id: "dydx",
+    name: "dYdX",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/17500/large/hjnIm9bV.jpg?1628009360",
+  },
+  {
+    id: "singularitynet",
+    name: "SingularityNET",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/2138/large/singularitynet.png?1548609559",
+  },
+  {
+    id: "nxm",
+    name: "Nexus Mutual",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11810/large/NXMmain.png?1674799570",
+  },
+  {
+    id: "arweave",
+    name: "Arweave",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4343/large/oRt6SiEN_400x400.jpg?1591059616",
+  },
+  {
+    id: "btse-token",
+    name: "BTSE Token",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/10807/large/BTSE_logo_Square.jpeg?1583965964",
+  },
+  {
+    id: "basic-attention-token",
+    name: "Basic Attention",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/677/large/basic-attention-token.png?1547034427",
+  },
+  {
+    id: "1inch",
+    name: "1inch",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13469/large/1inch-token.png?1608803028",
+  },
+  {
+    id: "baby-doge-coin",
+    name: "Baby Doge Coin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/16125/large/babydoge.jpg?1676303229",
+  },
+  {
+    id: "floki",
+    name: "FLOKI",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/16746/large/PNG_image.png?1643184642",
+  },
+  {
+    id: "kaspa",
+    name: "Kaspa",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/25751/large/kaspa-icon-exchanges.png?1653891958",
+  },
+  {
+    id: "gnosis",
+    name: "Gnosis",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/662/large/logo_square_simple_300px.png?1609402668",
+  },
+  {
+    id: "holotoken",
+    name: "Holo",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3348/large/Holologo_Profile.png?1547037966",
+  },
+  {
+    id: "nem",
+    name: "NEM",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/242/large/NEM_WC_Logo_200px.png?1642668663",
+  },
+  {
+    id: "oec-token",
+    name: "OKT Chain",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13708/large/WeChat_Image_20220118095654.png?1642471094",
+  },
+  {
+    id: "mx-token",
+    name: "MX",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/8545/large/MEXC_GLOBAL_LOGO.jpeg?1670213280",
+  },
+  {
+    id: "zcash",
+    name: "Zcash",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/486/large/circle-zcash-color.png?1547034197",
+  },
+  {
+    id: "cdai",
+    name: "cDAI",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9281/large/cDAI.png?1576467585",
+  },
+  {
+    id: "marumarunft",
+    name: "marumaruNFT",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/27672/la…e23f86-426d-4a0f-9d66-10da3d58baf5.png?1665158519",
+  },
+  {
+    id: "liquity-usd",
+    name: "Liquity USD",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/14666/large/Group_3.png?1617631327",
+  },
+  {
+    id: "safemoon",
+    name: "SafeMoon [OLD]",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/14362/large/174x174-white.png?1617174846",
+  },
+  {
+    id: "qtum",
+    name: "Qtum",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/684/large/Qtum_Logo_blue_CG.png?1637155875",
+  },
+  {
+    id: "ordinals",
+    name: "ORDI",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/30162/large/ordi.png?1683527689",
+  },
+  {
+    id: "theta-fuel",
+    name: "Theta Fuel",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/8029/large/1_0YusgngOrriVg4ZYx4wOFQ.png?1553483622",
+  },
+  {
+    id: "ethereum-name-service",
+    name: "Ethereum Name Service",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/19785/large/acatxTm8_400x400.jpg?1635850140",
+  },
+  {
+    id: "oasis-network",
+    name: "Oasis Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13162/large/rose.png?1605772906",
+  },
+  {
+    id: "fetch-ai",
+    name: "Fetch.ai",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/5681/large/Fetch.jpg?1572098136",
+  },
+  {
+    id: "chia",
+    name: "Chia",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/15174/large/zV5K5y9f_400x400.png?1620024414",
+  },
+  {
+    id: "celo",
+    name: "Celo",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11090/large/InjXBNx9_400x400.jpg?1674707499",
+  },
+  {
+    id: "ravencoin",
+    name: "Ravencoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3412/large/ravencoin.png?1548386057",
+  },
+  {
+    id: "audius",
+    name: "Audius",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12913/large/AudiusCoinLogo_2x.png?1603425727",
+  },
+  {
+    id: "decred",
+    name: "Decred",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/329/large/decred.png?1547034093",
+  },
+  {
+    id: "terra-luna-2",
+    name: "Terra",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/25767/large/01_Luna_color.png?1653556122",
+  },
+  {
+    id: "defichain",
+    name: "DeFiChain",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11757/large/symbol-defi-blockchain_200.png?1597306538",
+  },
+  {
+    id: "link",
+    name: "LINK",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/6450/large/linklogo.png?1547042644",
+  },
+  {
+    id: "staked-frax-ether",
+    name: "Staked Frax Ether",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1679886768",
+  },
+  {
+    id: "swipe",
+    name: "SXP",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9368/large/swipe.png?1566792311",
+  },
+  {
+    id: "aleph-zero",
+    name: "Aleph Zero",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/17212/large/gtmuTVa.png?1626853180",
+  },
+  {
+    id: "icon",
+    name: "ICON",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1060/large/icon-icx-logo.png?1547035003",
+  },
+  {
+    id: "illuvium",
+    name: "Illuvium",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/14468/large/logo-200x200.png?1682415398",
+  },
+  {
+    id: "stepn",
+    name: "STEPN",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/23597/large/gmt.png?1644658792",
+  },
+  {
+    id: "compound-governance-token",
+    name: "Compound",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/10775/large/COMP.png?1592625425",
+  },
+  {
+    id: "huobi-btc",
+    name: "Huobi BTC",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12407/large/Unknown-5.png?1599624896",
+  },
+  {
+    id: "astar",
+    name: "Astar",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/22617/large/astr.png?1642314057",
+  },
+  {
+    id: "jasmycoin",
+    name: "JasmyCoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13876/large/JASMY200x200.jpg?1612473259",
+  },
+  {
+    id: "bitcoin-gold",
+    name: "Bitcoin Gold",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/1043/large/bitcoin-gold-logo.png?1547034978",
+  },
+  {
+    id: "dao-maker",
+    name: "DAO Maker",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13915/large/4.png?1612838831",
+  },
+  {
+    id: "kusama",
+    name: "Kusama",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/9568/large/m4zRhP5e_400x400.jpg?1576190080",
+  },
+  {
+    id: "beldex",
+    name: "Beldex",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/5111/large/Beldex.png?1559189036",
+  },
+  {
+    id: "escoin-token",
+    name: "Escoin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13566/large/escoin-200.png?1609833886",
+  },
+  {
+    id: "convex-crv",
+    name: "Convex CRV",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/15586/large/convex-crv.png?1621255952",
+  },
+  {
+    id: "ethereum-pow-iou",
+    name: "EthereumPoW",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/26997/large/logo-clear.png?1661311105",
+  },
+  {
+    id: "blur",
+    name: "Blur",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/28453/large/blur.png?1670745921",
+  },
+  {
+    id: "tether-eurt",
+    name: "Euro Tether",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/17385/large/Tether_new.png?1683650223",
+  },
+  {
+    id: "tominet",
+    name: "tomiNet",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/28730/large/logo_for_token.png?1673690005",
+  },
+  {
+    id: "balancer",
+    name: "Balancer",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11683/large/Balancer.png?1592792958",
+  },
+  {
+    id: "yearn-finance",
+    name: "yearn.finance",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11849/large/yearn-finance-yfi.png?1676174746",
+  },
+  {
+    id: "wemix-token",
+    name: "WEMIX",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/12998/large/wemixcoin_color_200.png?1666768971",
+  },
+  {
+    id: "iotex",
+    name: "IoTeX",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3334/large/iotex-logo.png?1547037941",
+  },
+  {
+    id: "golem",
+    name: "Golem",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/542/large/Golem_Submark_Positive_RGB.png?1606392013",
+  },
+  {
+    id: "ankr",
+    name: "Ankr Network",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4324/large/U85xTl2.png?1608111978",
+  },
+  {
+    id: "ronin",
+    name: "Ronin",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/20009/large/ronin.jpg?1649184678",
+  },
+  {
+    id: "just",
+    name: "JUST",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/11095/large/JUST.jpg?1588175394",
+  },
+  {
+    id: "olympus",
+    name: "Olympus",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1628311611",
+  },
+  {
+    id: "harmony",
+    name: "Harmony",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4344/large/Y88JAze.png?1565065793",
+  },
+  {
+    id: "helium",
+    name: "Helium",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/4284/large/Helium_HNT.png?1612620071",
+  },
+  {
+    id: "magic",
+    name: "Magic",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/18623/large/magic.png?1656052146",
+  },
+  {
+    id: "gains-farm",
+    name: "Gains Farm",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/13703/large/gfarm_v2.png?1611035398",
+  },
+  {
+    id: "ontology",
+    name: "Ontology",
+    imageUrl:
+      "https://assets.coingecko.com/coins/images/3447/large/ONT.png?1583481820",
+  },
+];
+export default DROPDOWN_LIST;

--- a/src/hooks/useMediaQuery.js
+++ b/src/hooks/useMediaQuery.js
@@ -26,7 +26,7 @@ const useMediaQuery = (breakpoint) => {
     return () => {
       mediaQueryList.removeEventListener("change", handleChangeMedia);
     };
-  }, []);
+  }, [breakpoint]);
 
   return {
     mediaQuery,

--- a/src/stores/coinStore.js
+++ b/src/stores/coinStore.js
@@ -1,36 +1,6 @@
 import { produce } from "immer";
 import { create } from "zustand";
 
-import * as PAGE from "./mockData";
-
-// eslint-disable-next-line no-unused-vars
-const mockAxiosMarkets = (currency, coinsPerPage, pageNum, order) => {
-  // eslint-disable-next-line max-len
-  // 'BASE_URL/coins/markets?vs_currency=krw&order=market_cap_desc&per_page=180&page=2&sparkline=false&locale=en'
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      // 파라미터 받은대로 요청 후 가져옴
-      resolve(PAGE[`${currency}_${pageNum}`]);
-    }, 500);
-  });
-};
-/**
- * @param {number} pageNum 페이지네이션 넘버 (180개 단위 페이지)
- * @param {number} coinsPerPage 페이지 당 가져올 코인 갯수(180)
- * @param {string} currency 선택한 화폐 단위
- * @returns axios get 요청으로 가져온 180개 코인 리스트 반환
- */
-// eslint-disable-next-line no-unused-vars
-const getCoinsByPage = async (pageNum, coinsPerPage, currency) => {
-  const response = await mockAxiosMarkets(
-    currency,
-    coinsPerPage,
-    pageNum,
-    "market_cap_desc"
-  );
-  return response;
-};
-
 const coinStore = (set, get) => ({
   coinDB: {},
   /**

--- a/src/stores/userInputStore.js
+++ b/src/stores/userInputStore.js
@@ -115,7 +115,7 @@ const userInputStore = (set, get) => ({
     futureDate,
     pastMoney,
     futureMoney,
-    coinName,
+    coinInfo,
     currency
   ) => {
     // records 가 null이면 빈 배열로 시작
@@ -123,14 +123,17 @@ const userInputStore = (set, get) => ({
     // 새로운 레코드 생성
     const newRecord = {
       id: storedRecords.length,
-      coinName,
-      past: {
-        date: formatDateToString(pastDate),
-        money: formatMoneyToString(Math.round(pastMoney), currency),
+      coinInfo: {
+        name: coinInfo.name,
+        imageUrl: coinInfo.imageUrl,
       },
-      future: {
-        date: formatDateToString(futureDate),
-        money: formatMoneyToString(Math.round(futureMoney), currency),
+      before: {
+        dateString: formatDateToString(pastDate),
+        moneyString: formatMoneyToString(Math.round(pastMoney), currency),
+      },
+      after: {
+        dateString: formatDateToString(futureDate),
+        moneyString: formatMoneyToString(Math.round(futureMoney), currency),
       },
       currency,
     };

--- a/src/stores/userInputStore.js
+++ b/src/stores/userInputStore.js
@@ -58,6 +58,11 @@ const userInputStore = (set, get) => ({
     set(() => ({ selectedMoney: newMoney }));
   },
   calculatedMoney: -1,
+  setCalculatedMoney: (calcResult) => {
+    set(() => ({
+      calculatedMoney: calcResult,
+    }));
+  },
   selectedCurrency: "krw",
   setSelectedCurrency: (newCurrency) => {
     set(() => ({ selectedCurrency: newCurrency }));
@@ -72,7 +77,6 @@ const userInputStore = (set, get) => ({
         selectedMoney,
         selectedCoinInfo,
         selectedCurrency,
-        saveRecord,
       } = get();
       // API 요청을 통해 선택한 시점의 가격과 현재 가격을 가져옴
       const todayDate = new Date();
@@ -92,19 +96,7 @@ const userInputStore = (set, get) => ({
       ]);
       const [beforePrice, todayPrice] = coinPriceResponses;
       // calculatedMoney 를 계산: 오늘 가격 * (selectedMoney / 선택한 날짜의 가격)
-      const calculatedMoney = (
-        todayPrice *
-        (selectedMoney / beforePrice)
-      ).toFixed(2);
-      set({ calculatedMoney });
-      saveRecord(
-        selectedDate,
-        todayDate,
-        selectedMoney,
-        calculatedMoney,
-        selectedCoinInfo.name,
-        selectedCurrency
-      );
+      return (todayPrice * (selectedMoney / beforePrice)).toFixed(2);
     } catch (error) {
       throw new Error(error);
     }

--- a/src/stores/userInputStore.js
+++ b/src/stores/userInputStore.js
@@ -55,7 +55,7 @@ const userInputStore = (set, get) => ({
   },
   selectedMoney: 0,
   setSelectedMoney: (newMoney) => {
-    set(() => ({ selectedoMoney: newMoney }));
+    set(() => ({ selectedMoney: newMoney }));
   },
   calculatedMoney: -1,
   selectedCurrency: "krw",

--- a/src/stores/userInputStore.js
+++ b/src/stores/userInputStore.js
@@ -39,6 +39,9 @@ const userInputStore = (set, get) => ({
     imageUrl:
       "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579",
   },
+  setSelectedCoinInfo: (newCoinInfo) => {
+    set(() => ({ selectedCoinInfo: newCoinInfo }));
+  },
   // default: 5년 전 오늘 날짜
   selectedDate: (() => {
     const today = new Date();
@@ -47,9 +50,18 @@ const userInputStore = (set, get) => ({
     fiveYearsAgo.setFullYear(today.getFullYear() - 5);
     return fiveYearsAgo;
   })(),
-  selectedMoney: 1500,
+  setSelectedDate: (newDate) => {
+    set(() => ({ selectedDate: newDate }));
+  },
+  selectedMoney: 0,
+  setSelectedMoney: (newMoney) => {
+    set(() => ({ selectedoMoney: newMoney }));
+  },
   calculatedMoney: -1,
   selectedCurrency: "krw",
+  setSelectedCurrency: (newCurrency) => {
+    set(() => ({ selectedCurrency: newCurrency }));
+  },
   /**
    * @description userInputStore의 상태값들을 토대로 사용자가 입력한 금액이 지금은 얼마가 되었는지 계산
    */


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 버그 수정
- [X] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [X] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### 이슈 번호
<!-- 아래 링크에 이슈번호를 적어주세요. 예) .../0-crypto-meter-technokings/issues/7 -->
https://github.com/codeit-bootcamp-frontend/0-crypto-meter-technokings/issues/49

### Key Changes 
- InputBoard 컴포넌트에 날짜 선택 기능을 추가했습니다.
- InputBoard 컴포넌트에 금액 설정 기능을 추가했습니다.
- InputBoard 컴포넌트에 코인 선택 기능을 추가했습니다.
- 오늘은 얼마일까 버튼을 누르면 오늘 금액이 계산되어 userInputStore의 calculatedMoney 상태가 업데이트 됩니다.
- 로컬 스토리지 저장 데이터구조를 개선했습니다. 
  - 기록 객체의 코인의 이미지 url또한 저장합니다.
- SearchHistoryListItem에서 로컬 스토리지를 참조하여 각 기록을 렌더링하게 했습니다.
- DropdownList는 정적인 180개 코인을 가지고 있게 했습니다. 
  - 동적인 데이터를 가지려면 api호출 또는 coinDB에서 페이지를 가져오게 됩니다. 하지만 coinDB는 초기값이 비어있으며, 처음으로 coinDB에 페이지를 add해주는 타이밍과 위치가 애매한 부분이 있습니다. Table이 마운팅 될 때 api호출을 통하여 coinDB의 첫 페이지를 업데이트 할 예정이지만, InputBoard의 dropdownlist또한 마운트가 동시에 되기에 Table이 업데이트한 뒤에 coinDB를 조회한다는 보장이 없고, api호출을 하게 된다면 두 컴포넌트가 비슷한 타이밍에 api호출을 하게 되어서 순서가 보장되지 않는 단점이 있습니다. 따라서 정적인 180개 데이터를 들고 있게 하는 것이 좋아보입니다. 정적인 데이터라서 최신 데이터가 아닐 수 있다는 미미한 단점이 있으나, 추후 드롭다운 내 검색 기능이 추가되면 해결될 것 같습니다.

### How it Works
- InputBoard 컴포넌트에서 userInputStore의 상태와 액션들을 대거 구독합니다.
- 구독하는 상태들과 액션들을 자식 Input 컴포넌트들로 props로 전해줍니다.
- 각 Input 컴포넌트들은 인풋의 값에 따라 맞는 액션을 통해 상태를 업데이트 합니다.
- 오늘은 얼마일까 버튼을 누르면, form의 submit이 되면서 submit핸들러 함수에서 calculate액션을 호출합니다.
- calculate액션 안에서 api호출을 통해 선택한 코인의 오늘의 가격을 가져와, 선택한 금액이 얼마가 되었는지 계산합니다.
- 핸들러 함수에서 calculate 액션이 반환한 결과값을 가지고 calculatedMoney를 업데이트하고, 로컬 스토리지에 기록을 저장하는 saveRecord액션을 호출합니다. 

### To Reviewers
- 애매하거나 같이 얘기해보고 싶은 부분
