### PR TITLE
:sparkles: CoinStore에 getPageSlice 액션 추가

### DIFF
--- a/src/stores/coinStore.js
+++ b/src/stores/coinStore.js
@@ -23,6 +23,10 @@ const coinStore = (set, get) => ({
     const { coinDB } = get();
     return coinDB[`${currency}_${pageNum}`];
   },
+  getPageSlice: (pageNum, currency, startIdx, length) => {
+    const { coinDB } = get();
+    return coinDB[`${currency}_${pageNum}`].slice(startIdx, startIdx + length);
+  },
   /**
    * @param {coinObject[]} coinList 180개 코인 객체가 담긴 배열
    * @param {number} pageNum coinDB에 저장할 페이지(180개 단위) 번호


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### 이슈 번호
<!-- 아래 링크에 이슈번호를 적어주세요. 예) .../0-crypto-meter-technokings/issues/7 -->
https://github.com/codeit-bootcamp-frontend/0-crypto-meter-technokings/issues/61

### Key Changes 
- coinStore에 getPageSlice 액션을 추가했습니다.

### How it Works
```js
  // coinDB krw_1 번 페이지의 0번째 인덱스부터 30개를 배열로 반환합니다.
  const page = getPageSlice(1, "krw", 0, 30);
```

Closes #61
