### PR TITLE
:children_crossing: InputBoard 초기날짜 1년 전으로 수정

### DIFF
--- a/src/components/InputBoard/InputBoard.jsx
+++ b/src/components/InputBoard/InputBoard.jsx
@@ -41,7 +41,9 @@ const InputBoard = () => {
     const today = new Date();
     const fiveYearsAgo = new Date(today.toLocaleDateString());
 
-    fiveYearsAgo.setFullYear(today.getFullYear() - 5);
+    fiveYearsAgo.setFullYear(
+      today.getFullYear() - import.meta.env.VITE_PAST_YEARS
+    );
     return fiveYearsAgo;
   });
   const [inputCoin, setInputCoin] = useState({

--- a/src/stores/userInputStore.js
+++ b/src/stores/userInputStore.js
@@ -38,13 +38,15 @@ const userInputStore = (set, get) => ({
   setSelectedCoinInfo: (newCoinInfo) => {
     set(() => ({ selectedCoinInfo: newCoinInfo }));
   },
-  // default: 5년 전 오늘 날짜
+  // default: PAST_YEARS년 전 오늘 날짜
   selectedDate: (() => {
     const today = new Date();
-    const fiveYearsAgo = new Date(today.toLocaleDateString());
+    const defaultDate = new Date(today.toLocaleDateString());
 
-    fiveYearsAgo.setFullYear(today.getFullYear() - 5);
-    return fiveYearsAgo;
+    defaultDate.setFullYear(
+      today.getFullYear() - Number(import.meta.env.VITE_PAST_YEARS)
+    );
+    return defaultDate;
   })(),
   setSelectedDate: (newDate) => {
     set(() => ({ selectedDate: newDate }));
@@ -137,9 +139,9 @@ const userInputStore = (set, get) => ({
       },
       selectedDate: (() => {
         const today = new Date();
-        const fiveYearsAgo = new Date(today.toLocaleDateString());
-        fiveYearsAgo.setFullYear(today.getFullYear() - 5);
-        return fiveYearsAgo;
+        const defaultDate = new Date(today.toLocaleDateString());
+        defaultDate.setFullYear(today.getFullYear() - 5);
+        return defaultDate;
       })(),
       selectedMoney: 0,
       calculatedMoney: -1,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [X] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

### Key Changes 
- 초기 날짜를 5년 전에서 1년 전 날짜로 변경했습니다. 

### How it Works
- 기존에 static하게 5라고 들어가 있던 부분을 .env에 PAST_YEARS라는 이름으로 몇년 전인지 넣어두고 사용하게 했습니다.
- .env파일 업데이트가 필요합니다. 
